### PR TITLE
[이재훈] 계정 도메인 추가

### DIFF
--- a/src/main/java/com/example/communityforum/domain/Board.java
+++ b/src/main/java/com/example/communityforum/domain/Board.java
@@ -25,6 +25,8 @@ public class Board {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Setter @ManyToOne(optional = false) private UserAccount userAccount; // 유저 정보
+
     @Setter
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)
@@ -34,7 +36,7 @@ public class Board {
     @Setter @Column(nullable = false, length = 500) private String content;  // 본문
 
 
-    @OrderBy("id")
+    @OrderBy("registeredDate desc")
     @OneToMany(mappedBy = "board", cascade = CascadeType.ALL)
     @ToString.Exclude
     private final Set<BoardComment> boardComments = new LinkedHashSet<>();
@@ -46,14 +48,15 @@ public class Board {
 
     protected Board() {}
 
-    private Board(BoardType boardType, String title, String content) {
+    private Board(UserAccount userAccount, BoardType boardType, String title, String content) {
+        this.userAccount = userAccount;
         this.boardType = boardType;
         this.title = title;
         this.content = content;
     }
 
-    public static Board of(BoardType boardType, String title, String content) {
-        return new Board(boardType, title, content);
+    public static Board of(UserAccount userAccount, BoardType boardType, String title, String content) {
+        return new Board(userAccount, boardType, title, content);
     }
 
     @Override

--- a/src/main/java/com/example/communityforum/domain/BoardComment.java
+++ b/src/main/java/com/example/communityforum/domain/BoardComment.java
@@ -21,18 +21,20 @@ public class BoardComment {
     private Long id;
 
     @Setter @ManyToOne(optional = false) private Board board; // 게시글 (ID)
+    @Setter @ManyToOne(optional = false) private UserAccount userAccount; // 유저 정보
     @Setter @Column(nullable = false, length = 50) private String content; // 본문
     @CreatedDate @Column(nullable = false) private LocalDateTime registeredDate; // 생성일시
 
     protected BoardComment() {}
 
-    private BoardComment(Board board, String content) {
+    private BoardComment(Board board, UserAccount userAccount, String content) {
         this.board = board;
+        this.userAccount = userAccount;
         this.content = content;
     }
 
-    public static BoardComment of(Board board, String content){
-        return new BoardComment(board, content);
+    public static BoardComment of(Board board, UserAccount userAccount, String content){
+        return new BoardComment(board, userAccount, content);
     }
 
     @Override

--- a/src/main/java/com/example/communityforum/domain/UserAccount.java
+++ b/src/main/java/com/example/communityforum/domain/UserAccount.java
@@ -1,0 +1,60 @@
+package com.example.communityforum.domain;
+
+import com.example.communityforum.domain.constant.Role;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+import javax.persistence.*;
+import java.util.Objects;
+
+@Getter
+@ToString
+@Table
+@Entity
+public class UserAccount {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Setter @Column(nullable = false, length = 10) private String userId; // 로그인 아이디
+    @Setter @Column(nullable = false, length = 15) private String password; // 비밀번호
+    @Setter @Column(nullable = false, length = 10) private String userName; // 사용자 본명
+    @Setter @Column(nullable = false, length = 11) private String phone; // 휴대전화번호
+
+    @Setter
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private Role role; // 사용자 역할
+
+    @Setter @Column(nullable = false) private boolean term; // 사용자약관동의
+
+    protected UserAccount() {}
+
+    private UserAccount(String userId, String password, String userName, String phone,Role role, boolean term) {
+        this.userId = userId;
+        this.password = password;
+        this.userName = userName;
+        this.phone = phone;
+        this.role = role;
+        this.term = term;
+    }
+
+    public static UserAccount of(String userId, String password, String userName, String phone, Role role, boolean term) {
+        return new UserAccount(userId, password, userName, phone, role, term);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof UserAccount)) return false;
+        UserAccount userAccount = (UserAccount) o;
+        return id != null && id.equals(userAccount.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+}

--- a/src/main/java/com/example/communityforum/repository/UserAccountRepository.java
+++ b/src/main/java/com/example/communityforum/repository/UserAccountRepository.java
@@ -1,0 +1,7 @@
+package com.example.communityforum.repository;
+
+import com.example.communityforum.domain.UserAccount;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserAccountRepository extends JpaRepository<UserAccount,Long> {
+}

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,9 +1,14 @@
+-- 테스트 계정
+    insert into user_account(user_id, password, phone, user_name, role, term) VALUES
+    ('rko','123456','01011112222','이재훈','GENERAL',true)
+;
+
 -- 게시글
-    insert into board (board_type, title, content, registered_date, modified_date) values
-    ('FORUM','test title','test test test','2023-01-01 09:14:25', '2023-01-01 09:20:25'),
-    ('FORUM','test2 title','test2 test2 test2', '2023-01-02 09:14:25','2023-01-02 09:24:25');
+    insert into board (user_account_id, board_type, title, content, registered_date, modified_date) values
+    (1,'FORUM','test title','test test test','2023-01-01 09:14:25', '2023-01-01 09:20:25'),
+    (1,'FORUM','test2 title','test2 test2 test2', '2023-01-02 09:14:25','2023-01-02 09:24:25');
 
 -- 댓글
-    insert into board_comment (board_id, content, registered_date) values
-    (1,'lololol','2023-01-01 10:14:25'),
-    (2,'wowowow','2023-01-02 10:14:25')
+    insert into board_comment (user_account_id, board_id, content, registered_date) values
+    (1, 1,'lololol','2023-01-01 10:14:25'),
+    (1, 2,'wowowow','2023-01-02 10:14:25')

--- a/src/test/java/com/example/communityforum/repository/JpaRepositoryTest.java
+++ b/src/test/java/com/example/communityforum/repository/JpaRepositoryTest.java
@@ -2,10 +2,13 @@ package com.example.communityforum.repository;
 
 import com.example.communityforum.config.JpaConfig;
 import com.example.communityforum.domain.Board;
+import com.example.communityforum.domain.UserAccount;
 import com.example.communityforum.domain.constant.BoardType;
+import com.example.communityforum.domain.constant.Role;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 
@@ -14,21 +17,26 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.as;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.*;
 
 @DisplayName("JPA 연결 테스트")
 @Import(JpaConfig.class)
 @DataJpaTest
+@AutoConfigureTestDatabase(replace = Replace.NONE)
 class JpaRepositoryTest {
 
     private final BoardRepository boardRepository;
     private final BoardCommentRepository boardCommentRepository;
+    private final UserAccountRepository userAccountRepository;
 
     public JpaRepositoryTest(
             @Autowired BoardRepository boardRepository,
-            @Autowired BoardCommentRepository boardCommentRepository
+            @Autowired BoardCommentRepository boardCommentRepository,
+            @Autowired UserAccountRepository userAccountRepository
     ) {
         this.boardRepository = boardRepository;
         this.boardCommentRepository = boardCommentRepository;
+        this.userAccountRepository = userAccountRepository;
     }
 
     @DisplayName("select 테스트")
@@ -52,9 +60,12 @@ class JpaRepositoryTest {
     void givenTestData_whenInserting_thenWorksFine() {
         // Given
         long preCnt = boardRepository.count();
+        UserAccount userAccount = userAccountRepository.save(UserAccount.of("rko","pw","lee","01011112222",Role.GENERAL,true));
+        Board board = Board.of(userAccount, BoardType.FORUM, "new board", "new content");
 
         // When
-        Board savedBoard = boardRepository.save(Board.of(BoardType.FORUM,"new title", "test content"));
+        boardRepository.save(board);
+
 
         // Then
         assertThat(boardRepository.count()).isEqualTo(preCnt + 1);


### PR DESCRIPTION
## 작업 개요 (이슈 번호)
- #13 

## 작업 내용 (변경 사항)
- 인증 후 게시글, 댓글 작성이 가능하도록 구현해야하기 때문에 추후 테스트를 위해 계정 도메인 추가
- 그에 따른 게시글과 댓글 엔티티에 연관관계 설정
- 계정 Repository는 api가 노출되는 것을 피하기 위해 @RepositoryRestResource를 붙이지 않음
- 테스트 데이터에 테스트 계정 추가
- 테스트가 정상 작동하는 것까지 확인

## 리뷰 요청 사항